### PR TITLE
Se modifica el detalle del mensaje

### DIFF
--- a/src/app/dashboard/views/AdminVirgenView.tsx
+++ b/src/app/dashboard/views/AdminVirgenView.tsx
@@ -154,7 +154,7 @@ const AdminVirgenView = () => {
                 {/* Información adicional */}
                 <p className="text-xs text-gray-500
                               pl-9 flex justify-start">
-                  Mensaje de {userData?.user.nombre} {userData?.user.apellido}. {new Date(msg.fechaPublicacion).toLocaleString()}
+                  Fecha {new Date(msg.fechaPublicacion).toLocaleString()}
                 </p>
 
                 {/* Botones según el estado del mensaje */}

--- a/src/views/VirgenView.tsx
+++ b/src/views/VirgenView.tsx
@@ -222,7 +222,7 @@ const VirgenView = () => {
                     )}
 
                     <p className="text-xs text-gray-500">
-                    Mensaje de {userData?.user.nombre} {userData?.user.apellido}. {new Date(msg.fechaPublicacion).toLocaleString()}
+                    Fecha {new Date(msg.fechaPublicacion).toLocaleString()}
                     </p>
                   </>
                 ) : (


### PR DESCRIPTION
Se modifica para que solo muestre la fecha, antes decia nombre y apellido pero en realidad estaba capturando los datos del usuario logueado, no del que publica. Dentro del mensaje no vienen esos datos, a implementar